### PR TITLE
:recycle: refactor(clarity): Update CSP rules to allow Clarity scripts in backend

### DIFF
--- a/one-cgiar-back/src/loaders/express.ts
+++ b/one-cgiar-back/src/loaders/express.ts
@@ -29,7 +29,7 @@ export default ({app}: {app: express.Application}) => {
   app.use(function (req, res, next) {
     res.setHeader(
       'Content-Security-Policy',
-      "script-src 'self' https://apis.google.com http://clarisatest.ciat.cgiar.org/api/ https://initiativestest.ciat.cgiar.org/apiClarisa/* https://toc.loc.codeobia.com/api/*"
+      "script-src 'self' https://apis.google.com http://clarisatest.ciat.cgiar.org/api/ https://initiativestest.ciat.cgiar.org/apiClarisa/* https://toc.loc.codeobia.com/api/* https://www.clarity.ms/*"
     );
     res.setHeader('Cross-Origin-Resource-Policy', 'same-site');
     // Website you wish to allow to connect


### PR DESCRIPTION
Update CSP rules in the backend to allow loading scripts from Clarity